### PR TITLE
77 create endoints for activity type assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ bld/
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot
-#wwwroot/
+wwwroot/uploads/
 
 # Visual Studio 2017 auto generated files
 Generated\ Files/

--- a/Domain.Contracts/Repositories/IActivityRepository.cs
+++ b/Domain.Contracts/Repositories/IActivityRepository.cs
@@ -8,4 +8,5 @@ public interface IActivityRepository : IRepositoryBase<Activity>, IInternalRepos
     Task<PagedList<Activity>> GetModuleActivitiesAsync(int moduleId, RequestParams requestParams, bool trackChanges);
     Task<bool> AnyOverlappingAsync(int moduleId, DateTime startsAt, DateTime endsAt, int? excludeActivityId = null);
     Task<Activity?> GetActivityByIdAsync(Expression<Func<Activity, bool>> expression, bool trackChanges = false);
+    Task<IEnumerable<Activity>> GetByCourseIdAndTypeIdAsync(int courseId, int activityTypeId);
 }

--- a/Domain.Contracts/Repositories/IActivityTypeRepository.cs
+++ b/Domain.Contracts/Repositories/IActivityTypeRepository.cs
@@ -5,4 +5,5 @@ public interface IActivityTypeRepository : IRepositoryBase<ActivityType>, IInter
 {
     Task<IEnumerable<ActivityType>> GetAllAsync(bool trackChanges);
     Task<int?> GetAssignmentTypeIdAsync();
+    Task<ActivityType?> GetByIdAsync(int activityTypeId);
 }

--- a/Domain.Contracts/Repositories/IActivityTypeRepository.cs
+++ b/Domain.Contracts/Repositories/IActivityTypeRepository.cs
@@ -4,4 +4,5 @@ namespace Domain.Contracts.Repositories;
 public interface IActivityTypeRepository : IRepositoryBase<ActivityType>, IInternalRepositoryBase<ActivityType>
 {
     Task<IEnumerable<ActivityType>> GetAllAsync(bool trackChanges);
+    Task<int?> GetAssignmentTypeIdAsync();
 }

--- a/Domain.Contracts/Repositories/ICourseRepository.cs
+++ b/Domain.Contracts/Repositories/ICourseRepository.cs
@@ -7,4 +7,5 @@ public interface ICourseRepository : IRepositoryBase<Course>, IInternalRepositor
 {
     Task<Course?> GetCourseByIdAsync(int id, bool trackChanges = false);
     Task<PagedList<Course>> GetAllCoursesAsync(bool includeModules = false, bool includeActivities = false, RequestParams requestParams = null!, bool trackChanges = false);
+    Task<Course?> GetByStudentIdAsync(string studentUserId);
 }

--- a/Domain.Contracts/Repositories/IDocumentRepository.cs
+++ b/Domain.Contracts/Repositories/IDocumentRepository.cs
@@ -13,4 +13,5 @@ public interface IDocumentRepository : IRepositoryBase<Document>, IInternalRepos
     Task<PagedList<Document>> GetDocumentsByModuleAsync(RequestParams requestParams, int moduleId, bool trackChanges = false);
     Task<PagedList<Document>> GetDocumentsByActivityAsync(RequestParams requestParams, int activityId, bool trackChanges = false);
     Task<PagedList<Document>> GetDocumentsByUserAsync(RequestParams requestParams, string userId, bool trackChanges = false);
+    Task<Document?> GetDocumentForActivityAndUserAsync(int activityId, string studentUserId);
 }

--- a/LMS.Infrastructure/Data/MapperProfile.cs
+++ b/LMS.Infrastructure/Data/MapperProfile.cs
@@ -70,6 +70,12 @@ public class MapperProfile : Profile
                                              ? destination.StartsAt
                                              : src.StartsAt))
             .ReverseMap();
+        CreateMap<Activity, AssignmentDto>()
+            .ForMember(target => target.ModuleName, config => config.MapFrom(src => src.Module.Name))
+            .ForMember(target => target.CourseName, config => config.MapFrom(src => src.Module.Course.Name))
+            .ForMember(target => target.IsSubmitted, config => config.Ignore())
+            .ForMember(target => target.IsLate, config => config.Ignore())
+            .ForMember(target => target.SubmittedDocumentId, config => config.Ignore());
         #endregion
 
         #region Modules

--- a/LMS.Infrastructure/Repositories/ActivityRepository.cs
+++ b/LMS.Infrastructure/Repositories/ActivityRepository.cs
@@ -39,6 +39,13 @@ public class ActivityRepository(ApplicationDbContext context) : RepositoryBase<A
                     .FirstOrDefaultAsync();
     }
 
+    public async Task<IEnumerable<Activity>> GetByCourseIdAndTypeIdAsync(int courseId, int activityTypeId)
+    {
+        return await FindByCondition(a => a.Module.CourseId == courseId && a.ActivityTypeId == activityTypeId)
+                    .Include(a => a.Module)
+                    .ToListAsync();
+    }
+
     private static IQueryable<Activity> ApplyOrdering(IQueryable<Activity> activities, RequestParams requestParams)
     {
         if (string.IsNullOrEmpty(requestParams.OrderBy)) return activities;

--- a/LMS.Infrastructure/Repositories/ActivityTypeRepository.cs
+++ b/LMS.Infrastructure/Repositories/ActivityTypeRepository.cs
@@ -18,4 +18,7 @@ public class ActivityTypeRepository(ApplicationDbContext context) : RepositoryBa
         var assignmentType = await FindByCondition(at => at.Name == "Inlämningsuppgift").FirstOrDefaultAsync();
         return assignmentType?.Id;
     }
+
+    public async Task<ActivityType?> GetByIdAsync(int activityTypeId) =>
+        await FindByCondition(at => at.Id == activityTypeId).FirstOrDefaultAsync();
 }

--- a/LMS.Infrastructure/Repositories/ActivityTypeRepository.cs
+++ b/LMS.Infrastructure/Repositories/ActivityTypeRepository.cs
@@ -12,4 +12,10 @@ public class ActivityTypeRepository(ApplicationDbContext context) : RepositoryBa
             .OrderBy(at => at.Name)
             .ToListAsync();
     }
+
+    public async Task<int?> GetAssignmentTypeIdAsync()
+    {
+        var assignmentType = await FindByCondition(at => at.Name == "Inlämningsuppgift").FirstOrDefaultAsync();
+        return assignmentType?.Id;
+    }
 }

--- a/LMS.Infrastructure/Repositories/CourseRepository.cs
+++ b/LMS.Infrastructure/Repositories/CourseRepository.cs
@@ -25,7 +25,10 @@ public class CourseRepository(ApplicationDbContext context) : RepositoryBase<Cou
 
         return await PagedList<Course>.CreateAsync(query, requestParams.Page, requestParams.PageSize);
     }
-        
+
+    public async Task<Course?> GetByStudentIdAsync(string studentUserId) =>
+        await FindByCondition(c => c.Students.Any(student => student.Id.Equals(studentUserId))).FirstOrDefaultAsync();
+
     private static IQueryable<Course> ApplyOrdering(IQueryable<Course> courses, RequestParams requestParams)
     {
         if (string.IsNullOrEmpty(requestParams.OrderBy)) return courses
@@ -39,4 +42,5 @@ public class CourseRepository(ApplicationDbContext context) : RepositoryBase<Cou
             _ => courses
         };
     }
+
 }

--- a/LMS.Infrastructure/Repositories/DocumentRepository.cs
+++ b/LMS.Infrastructure/Repositories/DocumentRepository.cs
@@ -98,6 +98,13 @@ public class DocumentRepository(ApplicationDbContext context) : RepositoryBase<D
         return await PagedList<Document>.CreateAsync(documents, requestParams.Page, requestParams.PageSize);
     }
 
+    public async Task<Document?> GetDocumentForActivityAndUserAsync(int activityId, string studentUserId) =>
+        await FindByCondition(d => d.ActivityId == activityId
+                                && d.UploadedByUserId.Equals(studentUserId)
+                                && d.DeletedAt == null)
+            .OrderByDescending(d => d.UploadedAt)
+            .FirstOrDefaultAsync();
+
     private static IQueryable<Document> ApplyOrdering(IQueryable<Document> documents, RequestParams requestParams)
     {
         if (string.IsNullOrEmpty(requestParams.OrderBy)) return documents;

--- a/LMS.Presentation/Controllers/ActivitiesController.cs
+++ b/LMS.Presentation/Controllers/ActivitiesController.cs
@@ -31,7 +31,7 @@ namespace LMS.Presentation.Controllers
             return Ok(activities);
         }
 
-        [HttpGet("{id}")]
+        [HttpGet("{id:int}")]
         [Authorize(Roles = "Teacher, Student")]
         [SwaggerOperation(Summary = "Get activity by ID", Description = "Retrieves a specific activity by its ID within a module.")]
         [SwaggerResponse(StatusCodes.Status200OK, "Activity retrieved successfully", typeof(ActivityDto))]
@@ -45,7 +45,7 @@ namespace LMS.Presentation.Controllers
             return activity;
         }
 
-        [HttpPut("{id}")]
+        [HttpPut("{id:int}")]
         [Authorize(Roles = "Teacher")]
         [SwaggerOperation(Summary = "Update activity", Description = "Updates an existing activity within a module.")]
         [SwaggerResponse(StatusCodes.Status204NoContent, "Activity updated successfully")]
@@ -74,7 +74,7 @@ namespace LMS.Presentation.Controllers
             return CreatedAtAction(actionName: nameof(GetActivity), routeValues: new { moduleId, id = result.createdActivityId }, value: result.activityDto);
         }
 
-        [HttpDelete("{id}")]
+        [HttpDelete("{id:int}")]
         [Authorize(Roles = "Teacher")]
         [SwaggerOperation(Summary = "Delete activity", Description = "Deletes an existing activity within a module.")]
         [SwaggerResponse(StatusCodes.Status204NoContent, "Activity deleted successfully")]

--- a/LMS.Presentation/Controllers/ActivitiesController.cs
+++ b/LMS.Presentation/Controllers/ActivitiesController.cs
@@ -1,7 +1,9 @@
-﻿using LMS.Shared.Common;
+﻿using Domain.Models.Entities;
+using LMS.Shared.Common;
 using LMS.Shared.DTOs.ActivityDtos;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Service.Contracts;
 using Swashbuckle.AspNetCore.Annotations;
@@ -12,7 +14,7 @@ namespace LMS.Presentation.Controllers
     [Route("api/modules/{moduleId:int}/[controller]")]
     [ApiController]
     [Authorize]
-    public class ActivitiesController(IServiceManager serviceManager) : ControllerBase
+    public class ActivitiesController(IServiceManager serviceManager, UserManager<ApplicationUser> userManager) : ControllerBase
     {
 
         [HttpGet]
@@ -83,6 +85,23 @@ namespace LMS.Presentation.Controllers
         {
             await serviceManager.ActivityService.DeleteAsync(moduleId, id);
             return NoContent();
+        }
+
+        [HttpGet("assignments")]
+        [Authorize(Roles = "Student")]
+        [SwaggerOperation(Summary = "Get assignments by student", Description = "Retrieves a list of assignment activities the student is enrolled in.")]
+        [SwaggerResponse(StatusCodes.Status200OK, "Assignments retrieved successfully", typeof(IEnumerable<ActivityDto>))]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid request parameters")]
+        [SwaggerResponse(StatusCodes.Status401Unauthorized, "User is not authorized")]
+        [SwaggerResponse(StatusCodes.Status403Forbidden, "Access denied")]
+        public async Task<ActionResult<IEnumerable<AssignmentDto>>> GetStudentAssignments()
+        {
+            var user = await userManager.GetUserAsync(User);
+            if (user == null)
+                return Unauthorized("User not found.");
+
+            var assignments = await serviceManager.ActivityService.GetStudentAssignmentsAsync(user.Id);
+            return Ok(assignments);
         }
     }
 }

--- a/LMS.Presentation/Controllers/DocumentController.cs
+++ b/LMS.Presentation/Controllers/DocumentController.cs
@@ -171,7 +171,7 @@ public class DocumentsController(IServiceManager serviceManager, IWebHostEnviron
     }
 
     [HttpPost("upload")]
-    [Authorize(Roles = "Teacher")]
+    [Authorize(Roles = "Teacher, Student")]
     [SwaggerOperation(Summary = "Upload document", Description = "Uploads a document file to the server.")]
     [SwaggerResponse(StatusCodes.Status201Created, "Document uploaded successfully", typeof(int))]
     [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid file or parameters")]

--- a/LMS.Presentation/Controllers/DocumentController.cs
+++ b/LMS.Presentation/Controllers/DocumentController.cs
@@ -30,7 +30,7 @@ public class DocumentsController(IServiceManager serviceManager, IWebHostEnviron
         return Ok(documents);
     }
 
-    [HttpGet("{id}")]
+    [HttpGet("{id:int}")]
     [Authorize(Roles = "Teacher, Student")]
     [SwaggerOperation(Summary = "Get document by ID", Description = "Retrieves a specific document by its ID.")]
     [SwaggerResponse(StatusCodes.Status200OK, "Document retrieved successfully", typeof(DocumentDto))]
@@ -43,7 +43,7 @@ public class DocumentsController(IServiceManager serviceManager, IWebHostEnviron
         return Ok(document);
     }
 
-    [HttpGet("course/{courseId}")]
+    [HttpGet("course/{courseId:int}")]
     [Authorize(Roles = "Teacher, Student")]
     [SwaggerOperation(Summary = "Get documents by course", Description = "Retrieves all documents associated with a specific course.")]
     [SwaggerResponse(StatusCodes.Status200OK, "Documents retrieved successfully", typeof(IEnumerable<DocumentDto>))]
@@ -56,7 +56,7 @@ public class DocumentsController(IServiceManager serviceManager, IWebHostEnviron
         return Ok(documents);
     }
 
-    [HttpGet("module/{moduleId}")]
+    [HttpGet("module/{moduleId:int}")]
     [Authorize(Roles = "Teacher, Student")]
     [SwaggerOperation(Summary = "Get documents by module", Description = "Retrieves all documents associated with a specific module.")]
     [SwaggerResponse(StatusCodes.Status200OK, "Documents retrieved successfully", typeof(IEnumerable<DocumentDto>))]
@@ -125,7 +125,7 @@ public class DocumentsController(IServiceManager serviceManager, IWebHostEnviron
         return CreatedAtAction(nameof(GetDocument), new { id }, null);
     }
 
-    [HttpPut("{id}")]
+    [HttpPut("{id:int}")]
     [Authorize(Roles = "Teacher")]
     [SwaggerOperation(Summary = "Update document", Description = "Updates an existing document.")]
     [SwaggerResponse(StatusCodes.Status204NoContent, "Document updated successfully")]
@@ -139,7 +139,7 @@ public class DocumentsController(IServiceManager serviceManager, IWebHostEnviron
         return NoContent();
     }
 
-    [HttpPut("{id}/restore")]
+    [HttpPut("{id:int}/restore")]
     [Authorize(Roles = "Teacher")]
     [SwaggerOperation(Summary = "Restore document", Description = "Restores a deleted document.")]
     [SwaggerResponse(StatusCodes.Status204NoContent, "Document restored successfully")]
@@ -153,7 +153,7 @@ public class DocumentsController(IServiceManager serviceManager, IWebHostEnviron
         return NoContent();
     }
 
-    [HttpDelete("{id}")]
+    [HttpDelete("{id:int}")]
     [Authorize(Roles = "Teacher")]
     [SwaggerOperation(Summary = "Delete document", Description = "Deletes an existing document.")]
     [SwaggerResponse(StatusCodes.Status204NoContent, "Document deleted successfully")]

--- a/LMS.Presentation/Controllers/DocumentController.cs
+++ b/LMS.Presentation/Controllers/DocumentController.cs
@@ -69,7 +69,7 @@ public class DocumentsController(IServiceManager serviceManager, IWebHostEnviron
         return Ok(documents);
     }
 
-    [HttpGet("activity/{activityId}")]
+    [HttpGet("activity/{activityId:int}")]
     [Authorize(Roles = "Teacher, Student")]
     [SwaggerOperation(Summary = "Get documents by activity", Description = "Retrieves all documents associated with a specific activity.")]
     [SwaggerResponse(StatusCodes.Status200OK, "Documents retrieved successfully", typeof(IEnumerable<DocumentDto>))]
@@ -78,6 +78,19 @@ public class DocumentsController(IServiceManager serviceManager, IWebHostEnviron
     public async Task<ActionResult<IEnumerable<DocumentDto>>> GetDocumentsByActivity(int activityId, [FromQuery] RequestParams parameter)
     {
         var (documents, metaData) = await serviceManager.DocumentService.GetDocumentsByActivityAsync(activityId, parameter);
+        Response.Headers.Append("X-Pagination", JsonSerializer.Serialize(metaData));
+        return Ok(documents);
+    }
+
+    [HttpGet("submissions/{activityId:int}")]
+    [Authorize(Roles = "Teacher")]
+    [SwaggerOperation(Summary = "Get submissions for activity", Description = "Retrieves all document submissions for a specific activity.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Submissions retrieved successfully", typeof(IEnumerable<DocumentDto>))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "User is not authorized")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Access denied")]
+    public async Task<ActionResult<IEnumerable<DocumentDto>>> GetSubmissionsForActivity(int activityId, [FromQuery] RequestParams parameter)
+    {
+        var (documents, metaData) = await serviceManager.DocumentService.GetSubmissionsForActivityAsync(activityId, parameter);
         Response.Headers.Append("X-Pagination", JsonSerializer.Serialize(metaData));
         return Ok(documents);
     }

--- a/LMS.Services/ActivityService.cs
+++ b/LMS.Services/ActivityService.cs
@@ -108,6 +108,38 @@ public class ActivityService(IUnitOfWork unitOfWork, IMapper mapper) : ServiceBa
         }
     }
 
+    public async Task<IEnumerable<AssignmentDto>> GetStudentAssignmentsAsync(string studentUserId)
+    {
+        var assignmentTypeId = await unitOfWork.ActivityTypeRepository.GetAssignmentTypeIdAsync();
+        if (assignmentTypeId == null)
+            return [];
+
+        var course = await unitOfWork.CourseRepository.GetByStudentIdAsync(studentUserId);
+        if (course == null)
+            return [];
+
+        var assignments = await unitOfWork.ActivityRepository.GetByCourseIdAndTypeIdAsync(course.Id, assignmentTypeId.Value);
+
+        var assignmentDtos = new List<AssignmentDto>();
+        foreach (var assignment in assignments)
+        {
+            var submittedDocument = await unitOfWork.DocumentRepository.GetDocumentForActivityAndUserAsync(assignment.Id, studentUserId);
+
+            assignmentDtos.Add(new AssignmentDto
+            {
+                Id = assignment.Id,
+                Name = assignment.Name,
+                EndDate = assignment.EndsAt,
+                ModuleName = assignment.Module.Name,
+                CourseName = course.Name,
+                IsSubmitted = submittedDocument != null,
+                IsLate = submittedDocument != null && submittedDocument.UploadedAt > assignment.EndsAt,
+                SubmittedDocumentId = submittedDocument?.Id
+            });
+        }
+        return assignmentDtos;
+    }
+
     private void EnsureModuleExists(int moduleId)
     {
         if (moduleId == 0 || !unitOfWork.ActivityRepository.FindByCondition(activity => activity.ModuleId == moduleId).Any())

--- a/LMS.Services/ActivityService.cs
+++ b/LMS.Services/ActivityService.cs
@@ -35,9 +35,11 @@ public class ActivityService(IUnitOfWork unitOfWork, IMapper mapper) : ServiceBa
         EnsureModuleExists(moduleId);
         EnsureNotNull(activityCreateDto, "Activity data is null.");
         ValidateDateRange(activityCreateDto.StartsAt, activityCreateDto.EndsAt);
+        var activityType = await unitOfWork.ActivityTypeRepository.GetByIdAsync(activityCreateDto.ActivityTypeId)
+            ?? throw new NotFoundException($"Activity Type with ID {activityCreateDto.ActivityTypeId} not found.");
 
         var module = await unitOfWork.ModuleRepository.GetModuleByConditionAsync(module => module.Id == moduleId, false, false)
-                    ?? throw new NotFoundException($"Module with id '{moduleId}' not found.");
+            ?? throw new NotFoundException($"Module with id '{moduleId}' not found.");
 
         EnsureActivityWithinModule(activityCreateDto.StartsAt, activityCreateDto.EndsAt, module);
 
@@ -67,6 +69,9 @@ public class ActivityService(IUnitOfWork unitOfWork, IMapper mapper) : ServiceBa
         EnsureModuleExists(moduleId);
         EnsureNotNull(activityEditDto, "Activity data is null.");
         ValidateDateRange(activityEditDto.StartsAt, activityEditDto.EndsAt);
+        var activityType = await unitOfWork.ActivityTypeRepository.GetByIdAsync(activityEditDto.ActivityTypeId)
+            ?? throw new NotFoundException($"Activity Type with ID {activityEditDto.ActivityTypeId} not found.");
+
         var activity = await unitOfWork.ActivityRepository.GetActivityByIdAsync(activity => activity.Id == id && activity.ModuleId == moduleId, true);
 
         var module = await unitOfWork.ModuleRepository.GetModuleByConditionAsync(module => module.Id == moduleId, false, false)

--- a/LMS.Services/DocumentService.cs
+++ b/LMS.Services/DocumentService.cs
@@ -56,6 +56,14 @@ public class DocumentService(IUnitOfWork unitOfWork, IMapper mapper, UserManager
         return (mappedDocuments, documents.MetaData);
     }
 
+    public async Task<(IEnumerable<DocumentDto>, MetaData metaData)> GetSubmissionsForActivityAsync(int activityId, RequestParams requestParams, bool trackChanges = false)
+    {
+        ArgumentNullException.ThrowIfNull(requestParams, nameof(requestParams));
+        var submissions = await unitOfWork.DocumentRepository.GetDocumentsByActivityAsync(requestParams, activityId, trackChanges);
+        var mappedDocuments = mapper.Map<IEnumerable<DocumentDto>>(submissions.Items);
+        return (mappedDocuments, submissions.MetaData);
+    }
+
     public async Task ShareDocumentAsync(int documentId, string sharerUserId, int? courseId, int? moduleId, int? activityId)
     {
         var document = await unitOfWork.DocumentRepository.GetByIdAsync(documentId, true)

--- a/LMS.Shared/DTOs/ActivityDtos/AssignmentDto.cs
+++ b/LMS.Shared/DTOs/ActivityDtos/AssignmentDto.cs
@@ -1,0 +1,12 @@
+﻿namespace LMS.Shared.DTOs.ActivityDtos;
+public record AssignmentDto
+{
+    public int Id { get; init; }
+    public string Name { get; init; } = null!;
+    public DateTime EndDate { get; init; }
+    public string ModuleName { get; init; } = null!;
+    public string CourseName { get; init; } = null!;
+    public bool IsSubmitted { get; init; }
+    public bool IsLate { get; init; }
+    public int? SubmittedDocumentId { get; init; }
+}

--- a/Service.Contracts/IActivityService.cs
+++ b/Service.Contracts/IActivityService.cs
@@ -8,4 +8,5 @@ public interface IActivityService
     Task<(ActivityDto activityDto, int createdActivityId)> CreateAsync(int moduleId, ActivityCreateDto activityCreateDto);
     Task UpdateAsync(int moduleId, int id, ActivityEditDto activityEditDto);
     Task DeleteAsync(int moduleId, int id);
+    Task<IEnumerable<AssignmentDto>> GetStudentAssignmentsAsync(string studentUserId);
 }

--- a/Service.Contracts/IDocumentService.cs
+++ b/Service.Contracts/IDocumentService.cs
@@ -14,6 +14,7 @@ public interface IDocumentService
     Task<(IEnumerable<DocumentDto>, MetaData metaData)> GetDocumentsByModuleAsync(int moduleId, RequestParams requestParams, bool trackChanges = false);
     Task<(IEnumerable<DocumentDto>, MetaData metaData)> GetDocumentsByActivityAsync(int activityId, RequestParams requestParams, bool trackChanges = false);
     Task<(IEnumerable<DocumentDto>, MetaData metaData)> GetDocumentsByUserAsync(string userId, RequestParams requestParams, bool trackChanges = false);
+    Task<(IEnumerable<DocumentDto>, MetaData metaData)> GetSubmissionsForActivityAsync(int activityId, RequestParams requestParams, bool trackChanges = false);
     Task ShareDocumentAsync(int documentId, string sharerUserId, int? courseId, int? moduleId, int? activityId);
     Task<int> UploadAsync(IFormFile file, string webRootPath, string userId, int? courseId, int? moduleId, int? activityId);
     Task<(Stream stream, string fileName, string contentType)> DownloadAsync(int documentId);


### PR DESCRIPTION
## New Features
- Students can now view their assignment activities.
- Teachers can access assignments linked to specific modules.
- Added endpoint to retrieve student assignments filtered by activity type.
- Added endpoint to fetch document submissions per activity.
- Document upload functionality now supports both students and teachers.

## Technical Improvements
- Added `wwwroot/uploads/` to `.gitignore` to prevent unnecessary test document uploads.
- Introduced route constraints (`:int`) to several endpoints for improved URL validation.
- Extended `MapperProfile `to include mapping for `AssignmentDto`.