### PR TITLE
#37- Teacher-Modules-Page

### DIFF
--- a/LMS.Blazor.Client/Pages/Modules.razor
+++ b/LMS.Blazor.Client/Pages/Modules.razor
@@ -1,18 +1,18 @@
 ﻿@using LMS.Blazor.Client.Services
 @using LMS.Blazor.Client.Shared.Components
-@using LMS.Shared.DTOs.CourseDtos
+@using LMS.Shared.DTOs.ModuleDtos
 @using Microsoft.AspNetCore.Authorization
 
-@page "/courses"
+@page "/modules/{courseId}"
 @rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
 @attribute [Authorize(Roles = "Teacher")]
 
-<PageTitle>Kurser</PageTitle>
+<PageTitle>Moduler</PageTitle>
 
-<h3>Kurser</h3>
-@if (courses == null)
+<h3>Modules</h3>
+@if (modules == null)
 {
-    <p>Laddar kurser...</p>
+    <p>Laddar moduler...</p>
 }
 else
 {
@@ -23,29 +23,29 @@ else
                     <div class="col p-4">
                         <div class="row g-3">
                             <div class="col-12">
-                                <Section Title="Kurser"
+                                <Section Title="Moduler"
                                          Icon="@(builder => builder.AddMarkupContent(0, "<i class='bi bi-journal-code'></i>"))" 
-                                        HeaderActions="@(builder => builder.AddMarkupContent(0, "<a href='/' class='btn btn-primary'>+ Skapa kurs</a>"))">
+                                        HeaderActions="@(builder => builder.AddMarkupContent(0, "<a href='/' class='btn btn-primary'>+ Skapa modul</a>"))">
                                     <ul class="list-unstyled mb-0">
-                                        @if (courses.Count == 0)
+                                        @if (modules.Count == 0)
                                         {
-                                            <p>Inga kurser tillgängliga. Skapa en ny kurs för att komma igång!</p>
+                                            <p>Denna kurs har inga moduler...</p>
                                         }
                                         else
                                         {
-                                            @foreach (var course in courses) 
+                                            @foreach (var module in modules)
                                             {
-                                                var moduleCount = course.Modules?.Count() ?? 0;
-                                                var studentCount = course.Students?.Count() ?? 0;
+                                                var activityCount = module.Activities?.Count() ?? 0;
 
-                                                <NavLink class="nav-link" href=@($"modules/{course.Id}") Match=@NavLinkMatch.All>
-                                                    <CourseRow Title="@course.Name" Sub="@($"{studentCount} studenter • {moduleCount} moduler")">
+                                                <NavLink class="nav-link" href=@($"activity/{module.Id}") Match=@NavLinkMatch.All>
+                                                    <CourseRow Title="@module.Name" Sub="@($"{activityCount} Aktiviteter")">
                                                         <Icon><i class="bi bi-cpu"></i></Icon>
                                                         <Suffix><Badge Color="info">Aktiv</Badge></Suffix>
                                                     </CourseRow>
                                                 </NavLink>
                                             }
                                         }
+
                                     </ul>
                                 </Section>
                             </div>
@@ -59,14 +59,17 @@ else
 }
 
 @code {
+    [Parameter]
+    public string courseId { get; set; } = string.Empty;
+
     [Inject]
     private IApiService _apiService { get; set; } = default!;
 
-    private List<CourseDto>? courses;
+    private List<ModuleDto>? modules;
 
     protected override async Task OnInitializedAsync()
     {
-        var response = await _apiService.CallApiAsync<IEnumerable<CourseDto>>("api/courses?null&includeModules=true&includeActivities=false");
-        courses = response?.ToList();
+        var response = await _apiService.CallApiAsync<IEnumerable<ModuleDto>>($"api/courses/{courseId}:int/Module");
+        modules = response?.ToList();
     }
 }


### PR DESCRIPTION
Skapat sida för lärare att se moduler i en kurs.
Navigera via "Alla kurser" i menyn, sedan klicka på den kursen man vill gå in på.

Updated `Courses.razor` to improve loading messages and make course rows clickable links to their respective module pages. Added new `Modules.razor` file to display modules for a specific course, protected by authorization for teachers, with functionality to fetch and navigate through modules and their activities.