### PR TITLE
Fix theme switching issues

### DIFF
--- a/LMS.Blazor.Client/Components/ThemeSwitcher.razor
+++ b/LMS.Blazor.Client/Components/ThemeSwitcher.razor
@@ -29,10 +29,15 @@
         }
     }
 
-    protected override void OnInitialized()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        IsDarkTheme = ThemeService.CurrentTheme == "dark";
-        ThemeService.OnChange += OnThemeChanged;
+        if (firstRender)
+        {
+            await ThemeService.InitializeThemeAsync();
+            IsDarkTheme = ThemeService.CurrentTheme == "dark";
+            ThemeService.OnChange += OnThemeChanged;
+            StateHasChanged();
+        }
     }
 
     private void OnThemeChanged()

--- a/LMS.Blazor.Client/Services/ThemeService.cs
+++ b/LMS.Blazor.Client/Services/ThemeService.cs
@@ -5,16 +5,19 @@ public class ThemeService(IJSRuntime jsRuntime)
 {
     private const string LocalStorageKey = "theme";
     public string CurrentTheme { get; private set; } = "light";
+    private bool _isInitialized = false;
 
     public event Action? OnChange;
     public async Task InitializeThemeAsync()
     {
+        if (_isInitialized) return;
         var savedTheme = await jsRuntime.InvokeAsync<string>("localStorage.getItem", LocalStorageKey);
         if (!string.IsNullOrEmpty(savedTheme))
         {
             CurrentTheme = savedTheme;
         }
         await ApplyThemeAsync();
+        _isInitialized = true;
     }
 
     public async Task SetTheme(string theme)
@@ -22,10 +25,11 @@ public class ThemeService(IJSRuntime jsRuntime)
         CurrentTheme = theme;
         await jsRuntime.InvokeVoidAsync("localStorage.setItem", LocalStorageKey, theme);
         await ApplyThemeAsync();
+        await jsRuntime.InvokeVoidAsync("setTheme", theme);
         OnChange?.Invoke();
     }
 
-    private async Task ApplyThemeAsync()
+    public async Task ApplyThemeAsync()
     {
         await jsRuntime.InvokeVoidAsync("document.documentElement.setAttribute", "data-bs-theme", CurrentTheme);
     }

--- a/LMS.Blazor/Components/App.razor
+++ b/LMS.Blazor/Components/App.razor
@@ -17,12 +17,7 @@
     <Routes />
     <script src="_framework/blazor.web.js"></script>
     <script src="bootstrap/js/bootstrap.bundle.min.js"></script>
-
-    <script>
-        function setTheme(theme) {
-            document.documentElement.setAttribute('data-bs-theme', theme);
-        }
-    </script>
+    <script src="js/theme.js"></script>
 </body>
 
 </html>

--- a/LMS.Blazor/Components/Layout/MainLayout.razor
+++ b/LMS.Blazor/Components/Layout/MainLayout.razor
@@ -35,5 +35,9 @@
         {
             await ThemeService.InitializeThemeAsync();
         }
+        else
+        {
+            await ThemeService.ApplyThemeAsync();
+        }
     }
 }

--- a/LMS.Blazor/wwwroot/js/theme.js
+++ b/LMS.Blazor/wwwroot/js/theme.js
@@ -1,0 +1,45 @@
+﻿function setTheme(theme) {
+    document.documentElement.setAttribute('data-bs-theme', theme);
+}
+
+
+(function () {
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    setTheme(savedTheme);
+})();
+
+document.addEventListener('DOMContentLoaded', function () {
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    setTheme(savedTheme);
+});
+
+window.addEventListener('popstate', function () {
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    setTheme(savedTheme);
+});
+
+const observer = new MutationObserver(function (mutations) {
+    mutations.forEach(function (mutation) {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'data-bs-theme') {
+        } else if (mutation.type === 'childList' || mutation.type === 'attributes') {
+
+            const savedTheme = localStorage.getItem('theme') || 'light';
+            if (document.documentElement.getAttribute('data-bs-theme') !== savedTheme) {
+                setTheme(savedTheme);
+            }
+        }
+    });
+});
+
+observer.observe(document.documentElement, {
+    attributes: true,
+    childList: true,
+    subtree: true
+});
+
+setInterval(function () {
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    if (document.documentElement.getAttribute('data-bs-theme') !== savedTheme) {
+        setTheme(savedTheme);
+    }
+}, 100);


### PR DESCRIPTION
This pull request resolves issues related to theme switching in Blazor WebAssembly when `InteractiveWebAssemblyRenderMode(prerender: false)` is used.
#### Key improvements include:
- Refactored `ThemeService` to properly initialize and apply saved theme from `localStorage`
- Updated `ThemeSwitcher.razor` to handle theme changes after render and subscribe to theme updates
- Added `theme.js` with JavaScript logic to enforce theme consistency across navigation and DOM mutations
- Ensured fallback theme application in `MainLayout.razor` when prerendering is disabled